### PR TITLE
updated pricing page + new upgrade account page

### DIFF
--- a/scss/components/_error-message.scss
+++ b/scss/components/_error-message.scss
@@ -7,7 +7,7 @@
   //border-radius: 4px;
   clear: fix;
   
-  #error__icon {
+  .error__icon {
     background-color: indianred;
     color: whitesmoke;
     position: absolute;
@@ -21,7 +21,7 @@
     text-shadow: 1px 1px 1px firebrick;
   }
   
-  #error__message {
+  .error__message {
     background-color: whitesmoke;
     float: right;
     width: 90%;
@@ -65,7 +65,7 @@
     }
     
     .terms--copy > strong {
-      font-size: responsive 12px 14px;
+      //font-size: responsive 12px 14px;
     }
   }
 }
@@ -106,11 +106,11 @@
   .error--flag {
     width: 100%;
     
-    #error__icon {
+    .error__icon {
       width: 15%;
     }
     
-    #error__message {
+    .error__message {
       width: 85%;
     }
   }

--- a/scss/components/_progress-bars.scss
+++ b/scss/components/_progress-bars.scss
@@ -16,27 +16,37 @@
       top: 0;
       height: 30px;
       padding: 0 10px;
+      
+      .bar__figure {
+        //background-color: tomato;
+        position: relative;
+        float: right;
+        top: 50%;
+        transform: translateY(-50%);
+        animation: show-value 4s ease-out;
+      }      
     }
-    
+        
     .key1 {
-      width: 70%;
+      //width: 70%;
       transition: width 4s;
       animation: key1 4s ease-out;
     }
     
     .key2 {
-      width: 40%;
+      //width: 40%;
       transition: width 4s;
       animation: key2 4s ease-out;
     }
     
+/*
     @keyframes key1 {
       0% {
         width: 0;
       }
       
       100% {
-        width: 70%;
+        //width: 70%;
       }
     }
     
@@ -46,10 +56,12 @@
       }
       
       100% {
-        width: 40%;
+        //width: 40%;
       }
     }
-    
+*/
+        
+/*
     .key1:before, .key2:before {
       color: whitesmoke;
       //content: '70%';
@@ -61,12 +73,14 @@
     }
     
     .key1:before {
-      content: '70%';
+      //content: '70%';
+      content: attr(data-line);
     }
     
     .key2:before {
       content: '400 / 1,000';
     }    
+*/
     
     @keyframes show-value {
       0% {

--- a/scss/components/_standard-elements.scss
+++ b/scss/components/_standard-elements.scss
@@ -118,6 +118,29 @@
   }
 }
 
+.view--feature {
+  margin: 10px 0;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  
+  .feature__button {
+    background-color: $primary-color;
+    color: $highlight-color;
+    display: inline-block;
+    width: 50px;
+    //margin: 0 6px 0 0;
+    padding: 4px 10px;
+    text-align: center;
+    cursor: pointer;    
+  } 
+  
+  .feature__button.active {
+    background-color: $highlight-color;
+    color: $primary-color;    
+  }    
+}
+
 
 /* --------------------------------------------------------------
    Radio Button Defaults
@@ -177,6 +200,92 @@
 }
 
 .radio-button-list li .radio-check:before {
+  //background-color: tomato;
+  position: absolute;
+  display: block;
+  content: ' ';
+  width: 12px;
+  height: 12px;
+  top: 3px;
+  left: 3px;
+  border-radius: 100%;
+  transition: background 0.25s linear;
+}
+
+input[type=radio]:checked ~ .radio-check {
+  border: 3px solid $highlight-color;
+}
+
+input[type=radio]:checked ~ .radio-check:before {
+  background: $highlight-color;
+}
+
+input[type=radio]:checked ~ label {
+  color: $highlight-color;
+}
+
+
+
+
+/* --------------------------------------------------------------
+   Vertical Radio Button Defaults
+-------------------------------------------------------------- */
+.radio-button-list-vertical {
+  list-style: none outside none;
+}
+
+.radio-button-list-vertical li {
+  //background-color: peachpuff;
+  color: darkslategray;
+  position: relative;
+  display: flex;
+  align-items: center;
+  //float: left;
+  width: 125px;
+  height: 24px;
+  margin: 0 0 10px 0;
+  font-size: responsive 14px 16px;
+}
+
+.radio-button-list-vertical li input[type=radio] {
+  position: absolute;
+  display: none;
+  //visibility: hidden;
+}
+
+.radio-button-list-vertical li label {
+  //background-color: peru;
+  position: relative;
+  display: block;
+  //margin: auto;
+  padding-left: 30px;
+  cursor: pointer;
+  z-index: 5;
+  transition: all 0.25s linear;
+}
+
+.radio-button-list-vertical li:hover label {
+  color: $highlight-color;
+}
+
+.radio-button-list-vertical li .radio-check {
+  position: absolute;
+  display: block;
+  top: 0;
+  left: 0;
+  width: 24px;
+  height: 24px;
+  border: 3px solid darkslategray;
+  border-radius: 100%;
+  z-index: 3;
+  transition: border .25s linear;
+}
+
+.radio-button-list-vertical li:hover .radio-check {
+  border-color: $highlight-color;
+}
+
+.radio-button-list-vertical li .radio-check:before {
   //background-color: tomato;
   position: absolute;
   display: block;

--- a/scss/components/_tables.scss
+++ b/scss/components/_tables.scss
@@ -1,39 +1,51 @@
 .price__table__wrapper {
   margin-top: 40px;
   font-size: responsive 13px 15px;
-  //border-left: 1px solid silver;
-  //border-top: 1px solid silver;
   
   .price__table__content {
     //background-color: rgba($highlight-color, 0.1);
     
     .price__table__row {
-      //background-color: tan;
+      //background-color: whitesmoke;
       display: flex;
       flex-direction: row;
-      //width: 33.3333%;
       
       .price--table--heading {
         //background-color: rgba($primary-color, 0.1);
         color: $primary-color;
         font-family: 'domineregular', 'georgia', serif;
+        justify-content: center;
       }
       
       .price--table--cell {
         display: flex;
         align-items: center;
-        width: 25%;
+        width: 35%;
         padding: 20px 10px;
         border-right: 1px solid silver;
         border-bottom: 1px solid silver;
+        justify-content: center;
+        text-align: center;
+        
+        sup {
+          font-family: 'domineregular', 'georgia', serif;
+          font-size: 8px;
+          margin: -10px 0 0 3px;
+        }
       }
       
       #empty--cell {
         //background-color: rgba($primary-color, 0.1);
         width: 20%;
         border: none;
+        //border-top: 1px solid silver;
         border-right: 1px solid silver;
         border-bottom: 1px solid silver;
+      }
+      
+      .top--row {
+        font-size: responsive 16px 18px;
+        //border-top: 1px solid silver;
       }
       
       .bottom--row {
@@ -48,6 +60,8 @@
       .table--heading--col {
         //background-color: lightcoral;
         width: 20%;
+        justify-content: flex-start;
+        text-align: left;
       }
     }
   }
@@ -56,38 +70,32 @@
 .checkmark {
   //background-color: azure;
   position: relative;
-  //margin-left: calc(50% - 12px);
-  //margin: 0 6px 0 0;
-  margin: auto;
   
   &:after {
     content: ' ';
     position: absolute;
     display: block;
-    top: -7px;
-    left: -7px;
-    width: 7px;
-    height: 14px;
+    top: -10px;
+    left: -8px;
+    width: 8px;
+    height: 16px;
     border: solid $highlight-color;
     border-width: 0 3px 3px 0;
     transform: rotate(45deg);
   }
-  
-/*
-  &:before {
-    background-color: $highlight-color;
-    content: '';
-    //position: absolute;
-    display: block;    
-    top: 0;
-    left: 0;
-    width: 22px;
-    height: 22px;
-    border-radius: 22px;
-  }
-*/
 }
 
+.pricing--clauses {
+  margin-top: 20px;
+  
+  p {
+    display: block;
+    float: left;
+    margin: 0 20px 0 0;
+    font-family: 'domineregular', 'georgia', serif;
+    font-size: responsive 10px 12px;
+  }
+}
 
 .crossmark {
   //background-color: $highlight-color;
@@ -127,6 +135,77 @@
   }  
 }
 
+.premium--pricing--section {
+  //background-color: rgba($highlight-color, 0.2);
+  display: block;
+  width: 90%;
+  margin-top: 30px;
+  //padding: 30px;
+  clear: fix;
+  
+  .premium--intro {
+    color: $primary-color;
+    padding: 0 0 20px 0;
+    font-family: 'domineregular', 'georgia', serif;
+    font-size: responsive 16px 18px;
+    border-bottom: 1px solid silver;
+  }
+  
+  #premium--byline {
+    margin-bottom: 30px;
+  }
+  
+  ul.premium--benefits--list {
+    float: left;
+    width: 55%;
+    margin-right: 5%;
+    font-family: 'domineregular', 'georgia', serif;
+    font-size: responsive 13px 15px;
+    
+    li {
+      //background-color: pink;
+      position: relative;
+      display: block;
+      height: 30px;
+      margin-bottom: 15px;
+      padding-left: 45px;
+      //border-bottom: 1px solid silver;
+    }
+    
+    li:before {
+      content: ' ';
+      position: absolute;
+      display: block;
+      top: -4px;
+      left: 8px;
+      width: 8px;
+      height: 16px;
+      border: solid $highlight-color;
+      border-width: 0 3px 3px 0;
+      transform: rotate(45deg);
+    }    
+  }
+  
+  .get--premium {
+    background-color: rgba(cornflowerblue, 0.15);;
+    //background-color: rgba($highlight-color, 0.2);
+    display: block;
+    float: right;
+    width: 40%;
+    margin-top: 50px;
+    padding: 5px 20px;
+    text-align: center;
+    
+    p {
+      font-family: 'montserratregular', 'helvetica', sans-serif;
+    }
+    
+    button {
+      margin: 10px 0 20px 0;
+    }
+  }
+}
+
 
 
 
@@ -140,11 +219,32 @@
       .price__table__row {
         
         .price--table--cell {
-          padding: 10px;
+          width: 40%;
+          //padding: 10px;
+        }
+        
+        #empty--cell {
+          width: 22%;
+        }
+        
+        .table--heading--col {
+          width: 22%;
         }
       }
     }
-  }  
+  }
+  
+  .premium--pricing--section {
+    //background-color: azure;
+    width: 100%;
+    
+    ul.premium--benefits--list {
+      
+      li {
+        padding-left: 35px;
+      }
+    }
+  } 
 }
 
 
@@ -161,40 +261,76 @@
       .price__table__row {
         
         .price--table--cell {
-          width: 25%;
-          padding: 5px;
+          width: 37.5%;
+          height: 50px;
+          padding: 0 10px;
         }
-        
-/*
-        .clause {
-          font-size: 9px;
-          //text-align: center;
-        }
-*/
         
         #empty--cell {
+          width: 25%;
+        }
+        
+        .table--heading--col {
           width: 25%;
         }
       }
     }
   }
   
-/*
-  .checkmark {
-    //margin: 0 4px 0 0;
+  .premium--pricing--section {
+    width: 100%;
     
-    &:after {
-      top: 2px;
-      left: 5px;
-      width: 6px;
-      height: 11px;
+    ul.premium--benefits--list {
+      width: 100%;
     }
     
-    &:before {
-      width: 16px;
-      height: 16px;
-      border-radius: 16px;
+    .get--premium {
+      float: left;
+      width: 100%;
+      margin: 15px 0 0 0;
     }
-  }  
-*/
+  }
+}
+
+
+
+
+//Media queries - narrow Desktop view: 1600px wide
+@media only screen and (min-width: 1024px) and (max-width: 1600px) and (max-height: 1280px) {
+  .price__table__wrapper {
+    
+    .price__table__content {
+      
+      .price__table__row {
+        
+        .price--table--cell {
+          width: 37.5%;
+        }
+        
+        #empty--cell {
+          width: 25%;
+        }
+        
+        .table--heading--col {
+          width: 25%;
+        }
+      }
+    }
+  }
+  
+  .premium--pricing--section {
+    //background-color: lightsalmon;
+    width: 100%;
+    
+    ul.premium--benefits--list {
+      width: 100%;
+    }
+    
+    .get--premium {
+      float: left;
+      width: 100%;
+      margin: 15px 0 0 0;
+      padding: 5px 40px;
+    }
+  }
 }

--- a/scss/modules/_account-02.scss
+++ b/scss/modules/_account-02.scss
@@ -1,10 +1,11 @@
 p > strong {
   //color: $highlight-color;
   margin: 0 1px;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
   font-family: 'montserratregular' sans-serif;
-  font-size: 16px;
+  //font-size: 16px;
   font-weight: normal;
+  text-transform: uppercase;
 }
 
 .api__account__wrapper {

--- a/scss/modules/_home-01.scss
+++ b/scss/modules/_home-01.scss
@@ -23,6 +23,12 @@
     text-align: center;   
   }
   
+  .brace__top {
+    width: 70%;
+    margin: 0 auto;
+    margin-bottom: 30px;
+  }
+  
   .tags__row {
     //background-color: pink;
     display: flex;
@@ -37,7 +43,7 @@
       padding: 5px 10px;
       border-radius: 20px;
       font-family: 'montserratregular', 'helvetica', sans-serif;
-      font-size: responsive 14px 16px;
+      font-size: responsive 13px 15px;
       letter-spacing: 0.01em;
       text-align: center;                  
     }
@@ -52,10 +58,52 @@
   margin-top: 30px;
   
   p {
-    display: flex;
-    margin: 0 0 8px 0;
+    //display: flex;
+    margin: 0 0 10px 0;
     //text-align: justify;
   }  
+}
+
+.api--diagram {
+  //background-color: whitesmoke;
+  position: relative;
+  width: 100%;
+  margin-top: 25px;
+  //padding: 20px 0;
+  //border-top: 1px solid rgba($primary-color, 0.5);
+  
+  .brace__rotate {
+    width: 60%;
+    margin: 0 auto;
+    transform: rotate(180deg);
+  }
+  
+  img {
+    margin-top: -25px;
+  }
+  
+  #chart__text {
+    //display: block;
+    margin-top: 20px;
+    //padding: 0 100px;
+    text-align: center;
+    font-family: 'montserratregular', 'helvetica', sans-serif;
+    font-size: responsive 12px 14px;    
+  }
+  
+/*
+  #chart__text {
+    //background-color: pink;
+    position: absolute;
+    display: block;
+    //top: 300px;
+    left: 0;
+    width: 28%;
+    margin: 0;
+    font-family: 'montserratregular', 'helvetica', sans-serif;
+    font-size: responsive 11px 13px;
+  }
+*/
 }
 
 .home--start--section {
@@ -93,7 +141,7 @@
       color: whitesmoke;
       position: absolute;
       display: block;
-      top: 5px;
+      top: 0;
       left: 0;
       width: 40px;
       //height: 40px;
@@ -126,7 +174,27 @@
 @media only screen and (max-width: 767px) {
   #intro--home {
     width: 100%;
-    line-height: 34px;
+    line-height: 34px;    
+  }
+  
+  .lead--home {
+    
+    .brace__top {
+      width: 100%;
+    }
+    
+    .tags__row {
+      
+      span {
+        padding: 4px 8px;
+        border-radius: 16px;
+      }
+    }
+  }
+  
+  .api--diagram {
+    position: absolute;
+    display: none;
   }
 }
 
@@ -143,11 +211,27 @@
     //background-color: tan;
     width: 75%;
     margin-left: 10%;
+    
+    .brace__top {
+      width: 60%;
+    }
   }
   
   .home--intro--copy {
     width: 75%;
     margin-left: 10%;
+  }
+  
+  .api--diagram {
+    //background-color: rosybrown;
+    display: block;
+    width: 75%;
+    margin-left: 10%;
+    
+    img {
+      //width: 100%;
+      //height: 350px;
+    }
   }
   
   .home--start--section {

--- a/scss/modules/_mobile-nav-menu.scss
+++ b/scss/modules/_mobile-nav-menu.scss
@@ -81,7 +81,7 @@
     
     ul {
       //background-color: salmon;
-      background-color: rgba($primary-color, 0.4);
+      background-color: $primary-tint;
       position: absolute;
       width: 100%;
       left: 0;
@@ -160,6 +160,7 @@
       //background-color: goldenrod;
       
       ul {
+        //background-color: lightseagreen;
         padding: 5px 0;
         
         .footer-item {

--- a/scss/modules/_results.scss
+++ b/scss/modules/_results.scss
@@ -66,21 +66,6 @@
   padding: 0;
   
 /*
-  button.tab {
-    background-color: $primary-color;
-    color: $highlight-color;
-    margin-top: 10px;
-    padding: 4px 10px;
-    font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-    letter-spacing: 0.1em;    
-  }
-  
-  button.tab.active {
-    background-color: $highlight-color;
-    color: $primary-color;
-  }
-*/
-  
   .view--feature {
     //background-color: coral;
     margin-top: 10px;
@@ -101,6 +86,7 @@
       color: $primary-color;
     }
   }
+*/
   
   .place--container {
     margin-top: 15px;

--- a/scss/modules/_upgrade.scss
+++ b/scss/modules/_upgrade.scss
@@ -1,0 +1,37 @@
+.api--plans {
+  //background-color: bisque;
+  float: left;
+  width: 30%;
+  height: 200px;
+  
+  h3 {
+    @include h3-style-docs();
+    margin-bottom: 10px;
+  }
+}
+
+.api--plans--additions {
+  //background-color: seashell;
+  float: left;
+  width: 70%;
+  height: 200px;
+  //margin-top: 30px;
+  
+  h3 {
+    @include h3-style-docs();
+    margin-bottom: 10px;
+  }
+  
+  .btn-account-upgrade {
+    width: 40px;
+    height: 40px;
+    //font-family: 'montserratregular' sans-serif;
+    font-size: 20px;
+  }
+  
+  table {
+    padding-top: 10px;
+    margin-top: 20px;
+    border-top: 1px solid silver;
+  }
+}

--- a/scss/screen.scss
+++ b/scss/screen.scss
@@ -27,4 +27,5 @@
 //@import "modules/account";
 //@import "modules/account-01";
 @import "modules/account-02";
+@import "modules/upgrade";
 @import "modules/results";


### PR DESCRIPTION
01 revised pricing layout and info

02 new upgrade account page - needs further work

03 revised progress bars on account page to work with Iain’s Angular
script

04 refined view—feature buttons to be uniform across entire site

05 changed homepage styling


## Still to do

01  styles and interface for upgrade page

02 finalise home page, especially ‘getting started’ section at bottom of page

03 clean search results styles to differentiate between venue name and venue address

04 possible include placeholder text for entering dates in ‘explore’ sections

05 clean up ‘terms and conditions’ text to reflect changing of account types i.e. ‘free’ + ‘paid’ accounts

06 style bottom of documentation page text i.e. ‘Generated with apidoc 0.16.1 - 2016-10-10T12:41:45.070Z’

07 minor changes to be applied to homepage diagram